### PR TITLE
+feat: option to hide damage splash

### DIFF
--- a/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/core/Config.kt
@@ -2792,7 +2792,7 @@ object Config : Vigilant(
         type = PropertyType.SELECTOR, name = "Custom Damage Splash Style",
         description = "§b[WIP] §rReplaces Skyblock damage splashes with custom rendered ones.",
         category = "Miscellaneous", subcategory = "Quality of Life",
-        options = ["Off", "Comma", "Truncate"],
+        options = ["Off", "Comma", "Truncate","Hidden"],
         i18nName = "skytils.config.miscellaneous.quality_of_life.custom_damage_splash_style",
         i18nCategory = "skytils.config.miscellaneous",
         i18nSubcategory = "skytils.config.miscellaneous.quality_of_life"

--- a/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/DamageSplash.kt
+++ b/src/main/kotlin/gg/skytils/skytilsmod/features/impl/misc/DamageSplash.kt
@@ -56,6 +56,7 @@ object DamageSplash {
         val damageMatcher = damagePattern.matchEntire(strippedName) ?: return
         e.isCanceled = true
         entity.worldObj.removeEntity(e.entity)
+        if (Skytils.config.customDamageSplash == 3) return
         if (Skytils.config.hideDamageInBoss && DungeonFeatures.hasBossSpawned) return
         val name = entity.customNameTag
         val damage = damageMatcher.groups[1]!!.value.run {


### PR DESCRIPTION
adds an option to custom damage splash that completely disables damage numbers